### PR TITLE
Refresh and dedupe categories for account transactions

### DIFF
--- a/web/app/b/[budgetId]/accounts/[accountId]/page.tsx
+++ b/web/app/b/[budgetId]/accounts/[accountId]/page.tsx
@@ -144,8 +144,28 @@ export default function RegisterPage({ params }: { params: { budgetId: string; a
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [budgetId, accountId, sinceParam]);
 
-  const cats = catsResp?.categories || [];
-  const groups = catsResp?.groups || [];
+  useEffect(() => {
+    const handler = (e: any) => {
+      if (e.detail?.budgetId === budgetId) load();
+    };
+    window.addEventListener("categories:refresh", handler);
+    return () => window.removeEventListener("categories:refresh", handler);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [budgetId]);
+  const cats = useMemo(() => {
+    const map = new Map<string, Category>();
+    (catsResp?.categories || []).forEach((c) => {
+      if (!map.has(c.id)) map.set(c.id, c);
+    });
+    return Array.from(map.values());
+  }, [catsResp]);
+  const groups = useMemo(() => {
+    const map = new Map<string, Group>();
+    (catsResp?.groups || []).forEach((g) => {
+      if (!map.has(g.id)) map.set(g.id, g);
+    });
+    return Array.from(map.values());
+  }, [catsResp]);
   const catName = (id?: string | null) => cats.find((c) => c.id === id)?.name || (id ? "(unknown)" : "");
   const acctName = (id?: string | null) => allAccounts.find((a) => a.id === id)?.name || "";
   const payeeNames = Array.from(new Set(txs.map(t => t.payee_name).filter(Boolean))) as string[];

--- a/web/app/b/[budgetId]/accounts/page.tsx
+++ b/web/app/b/[budgetId]/accounts/page.tsx
@@ -134,13 +134,34 @@ export default function AllAccountsPage({ params }: { params: { budgetId: string
   }, [budgetId, sinceParam]);
 
   useEffect(() => {
+    const handler = (e: any) => {
+      if (e.detail?.budgetId === budgetId) load();
+    };
+    window.addEventListener("categories:refresh", handler);
+    return () => window.removeEventListener("categories:refresh", handler);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [budgetId]);
+
+  useEffect(() => {
     if (!addAccountId && allAccounts.length > 0) {
       setAddAccountId(allAccounts[0].id);
     }
   }, [allAccounts, addAccountId]);
 
-  const cats = catsResp?.categories || [];
-  const groups = catsResp?.groups || [];
+  const cats = useMemo(() => {
+    const map = new Map<string, Category>();
+    (catsResp?.categories || []).forEach((c) => {
+      if (!map.has(c.id)) map.set(c.id, c);
+    });
+    return Array.from(map.values());
+  }, [catsResp]);
+  const groups = useMemo(() => {
+    const map = new Map<string, Group>();
+    (catsResp?.groups || []).forEach((g) => {
+      if (!map.has(g.id)) map.set(g.id, g);
+    });
+    return Array.from(map.values());
+  }, [catsResp]);
   const catName = (id?: string | null) => cats.find((c) => c.id === id)?.name || (id ? "(unknown)" : "");
   const acctName = (id?: string | null) => allAccounts.find((a) => a.id === id)?.name || "";
   const payeeNames = Array.from(new Set(txs.map((t) => t.payee_name).filter(Boolean))) as string[];

--- a/web/app/b/[budgetId]/page.tsx
+++ b/web/app/b/[budgetId]/page.tsx
@@ -113,6 +113,9 @@ export default function BudgetPage({ params }: { params: { budgetId: string } })
       setRespA(a);
       setRespB(b);
       setAccts(await acctRes.json());
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new CustomEvent("categories:refresh", { detail: { budgetId } }));
+      }
     } catch (e: any) {
       setError(e.message || "Failed to load");
     } finally {


### PR DESCRIPTION
## Summary
- Deduplicate category and group lists on account transaction pages
- Refresh account pages when categories change
- Notify other pages after category updates

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e2553af08328947615c020183165